### PR TITLE
MessagePack.pack should return String instead of Array[UInt8]

### DIFF
--- a/src/message_pack.cr
+++ b/src/message_pack.cr
@@ -9,7 +9,7 @@ module MessagePack
   alias Table = Hash(String, Type)
 
   def self.pack(value : Type)
-    Packer.new.write(value).bytes
+    Packer.new.write(value).to_s
   end
 
   # Parses a string, returning a `MessagePack::Table`.


### PR DESCRIPTION
Like in Ruby and many other languages. If user want, he can call #bytes on string to get Array[UInt8]. And getting String from that Array is not so easy. In most cases I know user want String (write to file, to database, to socket) because there is no overloaded methods for Array of bytes.
Otherwise this moment must be documented to not to surprise Rubists a lot.

I understand that Crystal Strings are for UTF-8 strings, not arrays of bytes, but in real life most libraries recieved string not Array[UInt8]. Maybe it will be better way to define some String subclass like ByteString with overloaded #size and some other methods, adopted for array of bytes, so all libraries works with strings will still works (also more properly).
