### PR TITLE
add benchmarks, comparing with ruby

### DIFF
--- a/bench/pack.cr
+++ b/bench/pack.cr
@@ -1,0 +1,65 @@
+require "../src/msgpack"
+
+def test_pack(name, count, &block : Int32 -> Slice(UInt8))
+  t = Time.now
+  print name
+  res = 0
+  count.times do |i|
+    res += block.call(i).size
+  end
+  puts " = #{res}, #{Time.now - t}"
+end
+
+t = Time.now
+
+# =============================================
+
+s = "a" * 200
+test_pack("small string", 1000000) do
+  MessagePack::Packer.new.write(s).to_slice
+end
+
+# =============================================
+
+s = "a" * 200000
+test_pack("big string", 10000) do
+  MessagePack::Packer.new.write(s).to_slice
+end
+
+# =============================================
+
+h = {} of String => String
+1000.times do |i|
+  h["key#{i}"] = "value#{i}"
+end
+
+test_pack("hash string string", 10000) do
+  MessagePack::Packer.new.write(h).to_slice
+end
+
+# =============================================
+
+h2 = {} of String => Float64
+1000.times do |i|
+  h2["key#{i}"] = i / 10.0.to_f64
+end
+
+test_pack("hash string float64", 10000) do
+  MessagePack::Packer.new.write(h2).to_slice
+end
+
+# =============================================
+
+arr = Array.new(1000) { |i| "data#{i}" }
+test_pack("array of strings", 10000) do
+  MessagePack::Packer.new.write(arr).to_slice
+end
+
+# =============================================
+
+arr = Array.new(3000) { |i| i / 10.0 }
+test_pack("array of floats", 20000) do
+  MessagePack::Packer.new.write(arr).to_slice
+end
+
+puts "Summary time: #{Time.now - t}"

--- a/bench/pack.cr
+++ b/bench/pack.cr
@@ -1,65 +1,22 @@
 require "../src/msgpack"
 
-def test_pack(name, count, &block : Int32 -> Slice(UInt8))
+def test_pack(name, count, data)
   t = Time.now
   print name
   res = 0
   count.times do |i|
-    res += block.call(i).size
+    res += MessagePack::Packer.new.write(data).to_slice.size
   end
   puts " = #{res}, #{Time.now - t}"
 end
 
 t = Time.now
 
-# =============================================
-
-s = "a" * 200
-test_pack("small string", 1000000) do
-  MessagePack::Packer.new.write(s).to_slice
-end
-
-# =============================================
-
-s = "a" * 200000
-test_pack("big string", 10000) do
-  MessagePack::Packer.new.write(s).to_slice
-end
-
-# =============================================
-
-h = {} of String => String
-1000.times do |i|
-  h["key#{i}"] = "value#{i}"
-end
-
-test_pack("hash string string", 10000) do
-  MessagePack::Packer.new.write(h).to_slice
-end
-
-# =============================================
-
-h2 = {} of String => Float64
-1000.times do |i|
-  h2["key#{i}"] = i / 10.0.to_f64
-end
-
-test_pack("hash string float64", 10000) do
-  MessagePack::Packer.new.write(h2).to_slice
-end
-
-# =============================================
-
-arr = Array.new(1000) { |i| "data#{i}" }
-test_pack("array of strings", 10000) do
-  MessagePack::Packer.new.write(arr).to_slice
-end
-
-# =============================================
-
-arr = Array.new(3000) { |i| i / 10.0 }
-test_pack("array of floats", 20000) do
-  MessagePack::Packer.new.write(arr).to_slice
-end
+test_pack("small string", 1000000, "a" * 200)
+test_pack("big string", 10000, "a" * 200000)
+test_pack("hash string string", 10000, (0..1000).reduce({} of String => String) { |h, i| h["key#{i}"] = "value#{i}"; h })
+test_pack("hash string float64", 10000, (0..1000).reduce({} of String => Float64) { |h, i| h["key#{i}"] = i / 10.0.to_f64; h })
+test_pack("array of strings", 10000, Array.new(1000) { |i| "data#{i}" })
+test_pack("array of floats", 20000, Array.new(3000) { |i| i / 10.0 })
 
 puts "Summary time: #{Time.now - t}"

--- a/bench/pack.rb
+++ b/bench/pack.rb
@@ -1,66 +1,23 @@
 require "msgpack"
 # gem install msgpack
 
-def test_pack(name, count, &block)
+def test_pack(name, count, data)
   t = Time.now
   print name
   res = 0
   count.times do |i|
-    res += block.call(i).bytesize
+    res += data.to_msgpack.bytesize
   end
   puts " = #{res}, #{Time.now - t}"
 end
 
 t = Time.now
 
-# =============================================
-
-s = "a" * 200
-test_pack("small string", 1000000) do
-  s.to_msgpack
-end
-
-# =============================================
-
-s = "a" * 200000
-test_pack("big string", 10000) do
-  s.to_msgpack
-end
-
-# =============================================
-
-h = {}
-1000.times do |i|
-  h["key#{i}"] = "value#{i}"
-end
-
-test_pack("hash string string", 10000) do
-  h.to_msgpack
-end
-
-# =============================================
-
-h2 = {}
-1000.times do |i|
-  h2["key#{i}"] = i / 10.0
-end
-
-test_pack("hash string float64", 10000) do
-  h2.to_msgpack
-end
-
-# =============================================
-
-arr = Array.new(1000) { |i| "data#{i}" }
-test_pack("array of strings", 10000) do
-  arr.to_msgpack
-end
-
-# =============================================
-
-arr = Array.new(3000) { |i| i / 10.0 }
-test_pack("array of floats", 20000) do
-  arr.to_msgpack
-end
+test_pack("small string", 1000000, "a" * 200)
+test_pack("big string", 10000, "a" * 200000)
+test_pack("hash string string", 10000, (0..1000).reduce({}) { |h, i| h["key#{i}"] = "value#{i}"; h })
+test_pack("hash string float64", 10000, (0..1000).reduce({}) { |h, i| h["key#{i}"] = i / 10.0; h })
+test_pack("array of strings", 10000, Array.new(1000) { |i| "data#{i}" })
+test_pack("array of floats", 20000, Array.new(3000) { |i| i / 10.0 })
 
 puts "Summary time: #{Time.now - t}"

--- a/bench/pack.rb
+++ b/bench/pack.rb
@@ -1,0 +1,66 @@
+require "msgpack"
+# gem install msgpack
+
+def test_pack(name, count, &block)
+  t = Time.now
+  print name
+  res = 0
+  count.times do |i|
+    res += block.call(i).bytesize
+  end
+  puts " = #{res}, #{Time.now - t}"
+end
+
+t = Time.now
+
+# =============================================
+
+s = "a" * 200
+test_pack("small string", 1000000) do
+  s.to_msgpack
+end
+
+# =============================================
+
+s = "a" * 200000
+test_pack("big string", 10000) do
+  s.to_msgpack
+end
+
+# =============================================
+
+h = {}
+1000.times do |i|
+  h["key#{i}"] = "value#{i}"
+end
+
+test_pack("hash string string", 10000) do
+  h.to_msgpack
+end
+
+# =============================================
+
+h2 = {}
+1000.times do |i|
+  h2["key#{i}"] = i / 10.0
+end
+
+test_pack("hash string float64", 10000) do
+  h2.to_msgpack
+end
+
+# =============================================
+
+arr = Array.new(1000) { |i| "data#{i}" }
+test_pack("array of strings", 10000) do
+  arr.to_msgpack
+end
+
+# =============================================
+
+arr = Array.new(3000) { |i| i / 10.0 }
+test_pack("array of floats", 20000) do
+  arr.to_msgpack
+end
+
+puts "Summary time: #{Time.now - t}"

--- a/src/message_pack/packer.cr
+++ b/src/message_pack/packer.cr
@@ -1,4 +1,4 @@
-class MessagePack::Packer
+struct MessagePack::Packer
   def self.new(io = MemoryIO.new : IO)
     packer = new(io)
     yield packer
@@ -141,7 +141,7 @@ class MessagePack::Packer
   end
 
   private def write_slice(slice)
-    IO.copy(MemoryIO.new(slice), @io)
+    @io.write(slice)
   end
 
   def to_slice


### PR DESCRIPTION
```
crystal pack.cr --release
small string = 203000000, 00:00:00.5024500
big string = 2000050000, 00:00:01.3175450
hash string string = 158010000, 00:00:02.1646770
hash string float64 = 159100000, 00:00:01.2170160
array of strings = 78930000, 00:00:00.8454770
array of floats = 540060000, 00:00:01.3040870
Summary time: 00:00:07.3524630
```

```
ruby pack.rb
small string = 202000000, 0.990964922
big string = 2000050000, 0.608941798
hash string string = 158010000, 0.624369164
hash string float64 = 159100000, 0.552940198
array of strings = 78930000, 0.228171944
array of floats = 540060000, 1.018431118
Summary time: 4.026427993
```

btw, it slower then ruby even after optimization in #4 (before optimization crystal summary time is 8.88s)

maybe @asterite know why?
