### PR TITLE
Benchmark for unpacker

### DIFF
--- a/bench/unpack.cr
+++ b/bench/unpack.cr
@@ -1,0 +1,42 @@
+require "../src/msgpack"
+
+def test_unpack(name, count, data)
+  slice = MessagePack::Packer.new.write(data).to_slice
+  t = Time.now
+  print name
+  res = 0
+  count.times do |i|
+    obj = yield(slice)
+    res += obj.size
+  end
+  puts " = #{res}, #{Time.now - t}"
+end
+
+def test_unpack_string(name, count, data)
+  test_unpack(name, count, data) do |slice|
+    MessagePack::Unpacker.new(slice).read_string
+  end
+end
+
+def test_unpack_hash(name, count, data)
+  test_unpack(name, count, data) do |slice|
+    MessagePack::Unpacker.new(slice).read_hash
+  end
+end
+
+def test_unpack_array(name, count, data)
+  test_unpack(name, count, data) do |slice|
+    MessagePack::Unpacker.new(slice).read_array
+  end
+end
+
+t = Time.now
+
+test_unpack_string("small string", 1000000, "a" * 200)
+test_unpack_string("big string", 10000, "a" * 200000)
+test_unpack_hash("hash string string", 10000, (0..1000).reduce({} of String => String) { |h, i| h["key#{i}"] = "value#{i}"; h })
+test_unpack_hash("hash string float64", 10000, (0..1000).reduce({} of String => Float64) { |h, i| h["key#{i}"] = i / 10.0.to_f64; h })
+test_unpack_array("array of strings", 10000, Array.new(1000) { |i| "data#{i}" })
+test_unpack_array("array of floats", 20000, Array.new(3000) { |i| i / 10.0 })
+
+puts "Summary time: #{Time.now - t}"

--- a/bench/unpack.rb
+++ b/bench/unpack.rb
@@ -1,0 +1,24 @@
+require "msgpack"
+
+def test_unpack(name, count, data)
+  slice = data.to_msgpack
+  t = Time.now
+  print name
+  res = 0
+  count.times do |i|
+    obj = MessagePack.unpack(slice)
+    res += obj.size
+  end
+  puts " = #{res}, #{Time.now - t}"
+end
+
+t = Time.now
+
+test_unpack("small string", 1000000, "a" * 200)
+test_unpack("big string", 10000, "a" * 200000)
+test_unpack("hash string string", 10000, (0..1000).reduce({}) { |h, i| h["key#{i}"] = "value#{i}"; h })
+test_unpack("hash string float64", 10000, (0..1000).reduce({}) { |h, i| h["key#{i}"] = i / 10.0; h })
+test_unpack("array of strings", 10000, Array.new(1000) { |i| "data#{i}" })
+test_unpack("array of floats", 20000, Array.new(3000) { |i| i / 10.0 })
+
+puts "Summary time: #{Time.now - t}"


### PR DESCRIPTION
crystal master

```
small string = 200000000, 00:00:01.1134670
big string = 2000000000, 00:00:02.8231170
hash string string = 10010000, 00:00:04.2064360
hash string float64 = 10010000, 00:00:02.7532150
array of strings = 10000000, 00:00:01.2473040
array of floats = 60000000, 00:00:03.4895660
Summary time: 00:00:15.6629580
```

ruby 

```
small string = 200000000, 3.966686
big string = 2000000000, 2.329444
hash string string = 10010000, 6.852912
hash string float64 = 10010000, 6.129595
array of strings = 10000000, 1.179191
array of floats = 60000000, 2.542375
Summary time: 23.04682
```

@asterite, arrays slower
