### PR TITLE
Unpacker optimizations and simplifications

### DIFF
--- a/src/message_pack/token.cr
+++ b/src/message_pack/token.cr
@@ -3,23 +3,27 @@ class MessagePack::Token
   property :type
 
   property :string_value
-  property :slice_value
   property :int_value
   property :uint_value
   property :float_value
   property :byte_number
   property :size
 
+  @size : Int64
+
   def initialize
     @type = :EOF
     @byte_number = 0
     @string_value = ""
-    @slice_value = nil
     @int_value = 0_i8
     @uint_value = 0_u8
     @float_value = 0.0_f32
 
-    @size = 0
+    @size = 0_i64
+  end
+
+  def size=(size)
+    @size = size.to_i64
   end
 
   def to_s(io)


### PR DESCRIPTION
Related to https://github.com/benoist/msgpack-crystal/pull/9

The optimizations are:
1. To read a string we can just create it with the size given, no need to allocate a slice and then copy that slice to create a string (so this reduces memory allocation by half). But for this you need to know `String.new(size) { |buffer| }` which is kind of low-level (but totally safe) :-)
2. When reading Array and Hash we know the size upfront, so we can create them in a more efficient way, avoiding extra reallocations of the internal buffer.
3. The Token's `@size` was a union of many integer types. I changed it to just `Int64` so multiple dispatches are avoided.
4. Avoid `[:true, :false].includes?(...)`. Every time you invoke this it allocates an array of two elements and calls `includes?` on it. A much efficient alternative is `{:true, :false}.includes?` which doesn't allocate memory. A yet faster is just switch on the values (to avoid a double comparison).

The simplification is to use the type in `read(...)` instead of having a bunch of `read_uint8`, `read_uint16`, etc. Using the type, and sizeof gets the job done.

In my case the summary time of the benchmark changes from 15s to 11.78s. 
