### PR TITLE
Remove global variable usage from bench scripts

### DIFF
--- a/bench/pack.cr
+++ b/bench/pack.cr
@@ -1,6 +1,16 @@
 require "../src/msgpack"
 
-$summary_packed = 0_u64
+module Global
+  @@summary_packed = 0_u64
+
+  def self.summary_packed
+    @@summary_packed
+  end
+
+  def self.summary_packed=(value)
+    @@summary_packed = value
+  end
+end
 
 def test_pack(name, count, data)
   t = Time.now
@@ -10,7 +20,7 @@ def test_pack(name, count, data)
     res += data.to_msgpack.size
   end
   puts " = #{res}, #{Time.now - t}"
-  $summary_packed += res
+  Global.summary_packed += res
 end
 
 def bytes(size : Int32) : Bytes
@@ -42,5 +52,5 @@ test_pack("array of mix int sizes", 2000, Array.new(30000) { |i| ints[i % ints.s
 data = [Array.new(30) { |i| i }, Array.new(30) { |i| i.to_s }, (0..30).reduce({} of Int32 => String) { |h, i| h[i] = i.to_s; h }, 1, "1"]
 test_pack("array of mix of data", 200, Array.new(10000) { |i| data[i % data.size] })
 
-puts "Summary packed size: #{$summary_packed} bytes"
+puts "Summary packed size: #{Global.summary_packed} bytes"
 puts "Summary time: #{Time.now - t}"

--- a/bench/unpack.cr
+++ b/bench/unpack.cr
@@ -1,6 +1,16 @@
 require "../src/msgpack"
 
-$summary_unpacked = 0_u64
+module Global
+  @@summary_unpacked = 0_u64
+
+  def self.summary_unpacked
+    @@summary_unpacked
+  end
+
+  def self.summary_unpacked=(value)
+    @@summary_unpacked = value
+  end
+end
 
 def test_unpack(name, count, klass, data)
   slice = data.to_msgpack
@@ -11,7 +21,7 @@ def test_unpack(name, count, klass, data)
     obj = klass.from_msgpack(slice)
     res += obj.is_a?(String) ? obj.bytesize : obj.size
   end
-  $summary_unpacked += res
+  Global.summary_unpacked += res
   puts " = #{res}, #{Time.now - t}"
 end
 
@@ -44,5 +54,5 @@ test_unpack("array of mix int sizes", 2000, Array(Int64), Array.new(30000) { |i|
 data = [Array.new(30) { |i| i }, Array.new(30) { |i| i.to_s }, (0..30).reduce({} of Int32 => String) { |h, i| h[i] = i.to_s; h }, 1, "1"]
 test_unpack("array of mix of data", 200, Array(Array(Int32) | Array(String) | Hash(Int32, String) | Int32 | String), Array.new(10000) { |i| data[i % data.size] })
 
-puts "Summary unpacked size: #{$summary_unpacked}"
+puts "Summary unpacked size: #{Global.summary_unpacked}"
 puts "Summary time: #{Time.now - t}"


### PR DESCRIPTION
Crystal no longer supports define or use global variables, rendering these benchmark scripts useless.

Update the code to use a fake `Global` module that solves that need.

Thank you. :heart: :heart: :heart: 
