### PR TITLE
Prevents failed nightly builds to affect status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: crystal
 crystal:
   - latest
   - nightly
+matrix:
+  allow_failures:
+    - crystal: nightly


### PR DESCRIPTION
It appears that Crystal nightly builds haven't been updated in a while, which is causing the build to appear as failed.

Following a common pattern, exclude `nightly` from affecting the build status of the project, but still test against it.

Thank you. :heart: :heart: :heart: 
