### PR TITLE
Update README.md to use new repository scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   msgpack:
-    github: benoist/msgpack-crystal
+    github: crystal-community/msgpack-crystal
 ```
 
 ## Usage


### PR DESCRIPTION
Since that this repository changed from `benoist/msgpack-crystal` to `crystal-community/msgpack-crystal`, I updated the README so that new user will correctly use the correct upstream.