### PR TITLE
Prefer Enums over Symbols for Token type

### DIFF
--- a/spec/lexer_spec.cr
+++ b/spec/lexer_spec.cr
@@ -16,7 +16,7 @@ private def it_lexes_int(description, int_value, bytes, file = __FILE__, line = 
   it "lexes #{description} from IO", file, line do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:INT)
+    token.type.should eq(Token::Type::Int)
     token.int_value.should eq(int_value)
   end
 end
@@ -27,7 +27,7 @@ private def it_lexes_uint(description, uint_value, bytes, file = __FILE__, line 
   it "lexes #{description} from IO", file, line do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:UINT)
+    token.type.should eq(Token::Type::Uint)
     token.uint_value.should eq(uint_value)
   end
 end
@@ -38,7 +38,7 @@ private def it_lexes_float(description, float_value, bytes, file = __FILE__, lin
   it "lexes #{description}", file, line do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:FLOAT)
+    token.type.should eq(Token::Type::Float)
     token.float_value.should eq(float_value)
   end
 end
@@ -49,7 +49,7 @@ private def it_lexes_string(description, string_value, bytes, file = __FILE__, l
   it "lexes #{description}", file, line do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(Token::Type::String)
     token.string_value.should eq(string_value)
   end
 end
@@ -61,7 +61,7 @@ private def it_lexes_binary(description, string_value, bytes, file = __FILE__, l
   it "lexes #{description}", file, line do
     lexer = Lexer.new io
     token = lexer.next_token
-    token.type.should eq(:BINARY)
+    token.type.should eq(Token::Type::Binary)
     token.binary_value.should eq(binary_value)
   end
 end
@@ -72,7 +72,7 @@ private def it_lexes_arrays(description, size, bytes, file = __FILE__, line = __
   it "lexes #{description}", file, line do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:ARRAY)
+    token.type.should eq(Token::Type::Array)
     token.size.should eq(size)
   end
 end
@@ -83,7 +83,7 @@ private def it_lexes_hashes(description, size, bytes, file = __FILE__, line = __
   it "lexes #{description}", file, line do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:HASH)
+    token.type.should eq(Token::Type::Hash)
     token.size.should eq(size)
   end
 end
@@ -92,7 +92,7 @@ private def it_raises(io, file = __FILE__, line = __LINE__)
   it "raises on lex #{io.inspect}", file, line do
     expect_raises ParseException do
       lexer = Lexer.new(io)
-      while lexer.next_token.type != :EOF
+      until lexer.next_token.type.eof?
         # Nothing
       end
     end
@@ -100,10 +100,10 @@ private def it_raises(io, file = __FILE__, line = __LINE__)
 end
 
 describe Lexer do
-  it_lexes("EOF", :EOF, UInt8[])
-  it_lexes("nil", :nil, UInt8[0xC0u8])
-  it_lexes("false", :false, UInt8[0xC2u8])
-  it_lexes("true", :true, UInt8[0xC3u8])
+  it_lexes("EOF", Token::Type::Eof, UInt8[])
+  it_lexes("nil", Token::Type::Null, UInt8[0xC0u8])
+  it_lexes("false", Token::Type::False, UInt8[0xC2u8])
+  it_lexes("true", Token::Type::True, UInt8[0xC3u8])
 
   it_lexes_uint("zero", 0, UInt8[0x00])
   it_lexes_uint("fix num", 127, UInt8[0x7f])

--- a/src/message_pack/lexer.cr
+++ b/src/message_pack/lexer.cr
@@ -28,23 +28,23 @@ class MessagePack::Lexer
 
     case current_byte
     when 0xC0
-      set_type_and_size(:nil, 0)
+      set_type_and_size(Token::Type::Null, 0)
     when 0xC2
-      set_type_and_size(:false, 0)
+      set_type_and_size(Token::Type::False, 0)
     when 0xC3
-      set_type_and_size(:true, 0)
+      set_type_and_size(Token::Type::True, 0)
     when 0xA0..0xBF
       consume_string(current_byte - 0xA0)
     when 0xE0..0xFF
-      @token.type = :INT
+      @token.type = Token::Type::Int
       @token.int_value = current_byte.to_i8
     when 0x00..0x7f
-      @token.type = :UINT
+      @token.type = Token::Type::Uint
       @token.uint_value = current_byte
     when 0x80..0x8f
-      set_type_and_size(:HASH, current_byte - 0x80)
+      set_type_and_size(Token::Type::Hash, current_byte - 0x80)
     when 0x90..0x9f
-      set_type_and_size(:ARRAY, current_byte - 0x90)
+      set_type_and_size(Token::Type::Array, current_byte - 0x90)
     when 0xC4
       consume_binary(next_byte)
     when 0xC5
@@ -78,13 +78,13 @@ class MessagePack::Lexer
     when 0xDB
       consume_string(read UInt32)
     when 0xDC
-      set_type_and_size(:ARRAY, read UInt16)
+      set_type_and_size(Token::Type::Array, read UInt16)
     when 0xDD
-      set_type_and_size(:ARRAY, read UInt32)
+      set_type_and_size(Token::Type::Array, read UInt32)
     when 0xDE
-      set_type_and_size(:HASH, read UInt16)
+      set_type_and_size(Token::Type::Hash, read UInt16)
     when 0xDF
-      set_type_and_size(:HASH, read UInt32)
+      set_type_and_size(Token::Type::Hash, read UInt32)
     else
       unexpected_byte!
     end
@@ -104,7 +104,7 @@ class MessagePack::Lexer
 
     unless byte
       @eof = true
-      @token.type = :EOF
+      @token.type = Token::Type::Eof
     end
 
     @token.byte_number = @byte_number
@@ -118,17 +118,17 @@ class MessagePack::Lexer
   end
 
   private def consume_uint(value)
-    @token.type = :UINT
+    @token.type = Token::Type::Uint
     @token.uint_value = value
   end
 
   private def consume_int(value)
-    @token.type = :INT
+    @token.type = Token::Type::Int
     @token.int_value = value
   end
 
   private def consume_float(value)
-    @token.type = :FLOAT
+    @token.type = Token::Type::Float
     @token.float_value = value
   end
 
@@ -136,14 +136,14 @@ class MessagePack::Lexer
     size = size.to_u32
     bytes = Bytes.new(size)
     @io.read_fully(bytes)
-    @token.type = :BINARY
+    @token.type = Token::Type::Binary
     @token.binary_value = bytes
     @byte_number += size
   end
 
   private def consume_string(size)
     size = size.to_u32
-    @token.type = :STRING
+    @token.type = Token::Type::String
     @token.string_value = String.new(size) do |buffer|
       @io.read_fully(Slice.new(buffer, size))
       {size, 0}

--- a/src/message_pack/token.cr
+++ b/src/message_pack/token.cr
@@ -1,5 +1,24 @@
 # :nodoc:
 class MessagePack::Token
+  enum Type
+    Eof
+    Null
+    False
+    True
+    Array
+    Hash
+    Structure
+    Int
+    Uint
+    Float
+    String
+    Binary
+
+    def to_s
+      super.upcase
+    end
+  end
+
   property :type
 
   property :binary_value
@@ -12,7 +31,7 @@ class MessagePack::Token
   property :used
 
   def initialize
-    @type = :EOF
+    @type = Type::Eof
     @byte_number = 0
     @binary_value = Bytes.new(0)
     @string_value = ""
@@ -30,15 +49,13 @@ class MessagePack::Token
 
   def to_s(io)
     case @type
-    when :nil
-      io << :nil
-    when :STRING
+    when .string?
       @string_value.inspect(io)
-    when :BINARY
+    when .binary?
       @binary_value.inspect(io)
-    when :INT
+    when .int?
       io << @int_value
-    when :FLOAT
+    when .float?
       io << @float_value
     else
       io << @type


### PR DESCRIPTION
I saw that the lexer was using Symbols and thought it might be preferable to use an Enum for the extra compile time checks that you get.  I'm ok if you don't want to merge it, as it can be a little wordier than the previous code.

One thing of note in this PR - Nil cannot be an Enum entry because it will create the helper method .nil? which collides with the method of the same name (actually Nil *can* be an Enum value, but it's confusing because of the above, so I opened https://github.com/crystal-lang/crystal/issues/7084 to discuss).  So, I chose Null instead as the Enum entry.