### PR TITLE
Stop Float from always being parsed ahead of Int in unions

### DIFF
--- a/spec/serialization_spec.cr
+++ b/spec/serialization_spec.cr
@@ -277,12 +277,18 @@ describe "MessagePack serialization" do
 
   describe "unpack unions" do
     context "work" do
-      type = Union(Array(Int32), Hash(String, String), String, Float64)
+      type = Union(Array(Int32), Hash(String, String), String, Float64, Int32)
 
       it "Float64" do
         val = type.from_msgpack(1.0.to_msgpack)
         val.class.should eq Float64
         val.should eq 1.0
+      end
+
+      it "Int32" do
+        val = type.from_msgpack(17.to_msgpack)
+        val.class.should eq Int32
+        val.should eq 17
       end
 
       it "Array" do

--- a/src/message_pack/from_msgpack.cr
+++ b/src/message_pack/from_msgpack.cr
@@ -98,6 +98,8 @@ def Union.new(pull : MessagePack::Unpacker)
     # Here we store types that are not primitive types
     {% non_primitives = [] of Nil %}
 
+    {% includes_int = T.includes?(Int8) || T.includes?(Int16) || T.includes?(Int32) || T.includes?(Int64) ||
+                      T.includes?(UInt8) || T.includes?(UInt16) || T.includes?(UInt32) || T.includes?(UInt64) %}
     {% for type, index in T %}
       {% if type == Nil %}
         return pull.read_nil if token.is_a?(MessagePack::Token::NullT)
@@ -109,7 +111,10 @@ def Union.new(pull : MessagePack::Unpacker)
                  type == UInt8 || type == UInt16 || type == UInt32 || type == UInt64 %}
         return {{type}}.new(pull) if token.is_a?(MessagePack::Token::IntT)
       {% elsif type == Float32 || type == Float64 %}
-        return {{type}}.new(pull) if token.is_a?(MessagePack::Token::FloatT) || token.is_a?(MessagePack::Token::IntT)
+        return {{type}}.new(pull) if token.is_a?(MessagePack::Token::FloatT)
+        {% unless includes_int %}
+          return {{type}}.new(pull) if token.is_a?(MessagePack::Token::IntT)
+        {% end %}
       {% else %}
         {% non_primitives << type %}
       {% end %}


### PR DESCRIPTION
This stops `(Float64 | Int32).from_msgpack(1.to_msgpack)` from always
being `1.0`. This only applies if the union contains both a float and an
int type.