### PR TITLE
Update for 0.34.0

### DIFF
--- a/src/message_pack/unpacker.cr
+++ b/src/message_pack/unpacker.cr
@@ -163,6 +163,8 @@ abstract class MessagePack::Unpacker
       token.size.times { skip_value }
     when Token::HashT
       token.size.times { skip_value; skip_value }
+    else
+      # nothing more to do
     end
   end
 
@@ -198,6 +200,8 @@ abstract class MessagePack::Unpacker
       token.size.times { _read_node(node) }
     when Token::HashT
       token.size.times { _read_node(node); _read_node(node) }
+    else
+      # nothing more to do
     end
 
     true


### PR DESCRIPTION
Just a quick fix up of two non-exhaustive `case` statements. Neither actually need to do anything, just adding an empty `else` to keep the compiler happy.