### PR TITLE
Fix parsing floats when in a union with a class that starts with "Int"

### DIFF
--- a/src/message_pack/from_msgpack.cr
+++ b/src/message_pack/from_msgpack.cr
@@ -110,7 +110,7 @@ def Union.new(pull : MessagePack::Unpacker)
         return {{type}}.new(pull) if token.is_a?(MessagePack::Token::IntT)
       {% elsif type == Float32 || type == Float64 %}
         return {{type}}.new(pull) if token.is_a?(MessagePack::Token::FloatT)
-        {% unless T.any? { |t| t.name.starts_with?("Int") } %}
+        {% unless T.any? { |t| t < Int } %}
           return {{type}}.new(pull) if token.is_a?(MessagePack::Token::IntT)
         {% end %}
       {% else %}


### PR DESCRIPTION
Currently if you have a union of `Float64` or `Float32` along with a class with a name that starts with "Int", it will fail to interpret integers as floats, for example:

```crystal
class InternalThing
  include MessagePack::Serializable
  @foo = "foo"
end

puts (Float64 | InternalThing).from_msgpack(1.to_msgpack)
```

Currently this throws an exception (expecting a HashT) whereas the expected behaviour is to turn the integer into a float. This PR restores the expected behaviour.