### PR TITLE
Fix discriminator bug

### DIFF
--- a/spec/serializable_spec.cr
+++ b/spec/serializable_spec.cr
@@ -359,6 +359,12 @@ module Discriminator
   struct Updated < Message
     getter updated_at : Time
   end
+
+  # NOTE: not in the parent discriminator mapping
+  struct Activity < Message
+    getter type : String
+    getter object : String
+  end
 end
 
 describe "MessagePack mapping" do
@@ -954,6 +960,15 @@ describe "MessagePack mapping" do
     # `Disciminator::Message` instead of the more specific types.
     created.as(Discriminator::Created).created_at.should eq time
     updated.as(Discriminator::Updated).updated_at.should eq time
+  end
+
+  it "allows subclasses not in discriminator mapping to be deserialized directly" do
+    activity = Discriminator::Activity.from_msgpack({type: "Other", id: 456, object: "note:123"}.to_msgpack)
+
+    activity.should be_a Discriminator::Activity
+    activity.type.should eq "Other"
+    activity.id.should eq 456
+    activity.object.should eq "note:123"
   end
 
   describe "namespaced classes" do

--- a/src/message_pack/serializable.cr
+++ b/src/message_pack/serializable.cr
@@ -141,7 +141,10 @@ module MessagePack
 
       macro inherited
         def self.new(pull : ::MessagePack::Unpacker)
-          super
+          instance = allocate
+          instance.initialize(__pull_for_msgpack_serializable: pull)
+          GC.add_finalizer(instance) if instance.responds_to?(:finalize)
+          instance
         end
       end
     end
@@ -268,7 +271,7 @@ module MessagePack
               {% key.raise "mapping keys must be one of StringLiteral, NumberLiteral, BoolLiteral, or Path, not #{key.class_name.id}" %}
             {% end %}
           {% end %}
-          {{value.id}}.new(__pull_for_msgpack_serializable: MessagePack::NodeUnpacker.new(node))
+          {{value.id}}.new(MessagePack::NodeUnpacker.new(node))
         {% end %}
         else
           raise ::MessagePack::UnpackError.new("Unknown '{{field.id}}' discriminator value: #{discriminator_value.inspect}", 0)


### PR DESCRIPTION
The discriminator defined in the parent type was being invoked indiscriminately when a subclass was being deserialized. This meant that all types needed to be defined in the parent discriminator. This isn't true of the `JSON::Serializable` discriminator, so this commit tweaks it here to have similar flexibility.

Full disclosure: I wrote [the original `use_msgpack_discriminator` code](https://github.com/crystal-community/msgpack-crystal/pull/69) based on the `{JSON,YAML}::Serializable` discriminators. It appears I misunderstood how parts of it worked.