### PR TITLE
Fix NamedTuple.from_msgpack with complex keys

### DIFF
--- a/spec/serialization_spec.cr
+++ b/spec/serialization_spec.cr
@@ -64,15 +64,24 @@ describe "MessagePack serialization" do
     end
 
     it "does for NamedTuple" do
-      data = Bytes[130, 161, 97, 1, 172, 64, 99, 111, 109, 112, 108, 101, 120, 95, 107, 101, 121, 165, 119, 111, 114, 107, 115]
+      data = Bytes[131, 161, 97, 1, 172, 64, 99, 111, 109, 112, 108, 101, 120, 95, 107, 101, 121, 165, 119, 111, 114, 107, 115, 177, 107, 101, 121, 95, 119, 105, 116, 104, 95, 34, 113, 117, 111, 116, 101, 115, 34, 170, 97, 108, 115, 111, 32, 119, 111, 114, 107, 122]
 
-      named_tuple = NamedTuple(a: Int32, "@complex_key": String).from_msgpack(data)
+      named_tuple = NamedTuple(
+        a: Int32,
+        "@complex_key": String,
+        %[key_with_"quotes"]: String,
+      ).from_msgpack(data)
 
       named_tuple.should eq({
-        a:              1,
-        "@complex_key": "works",
+        a:                    1,
+        "@complex_key":       "works",
+        %[key_with_"quotes"]: "also workz",
       })
-      named_tuple.should be_a(NamedTuple(a: Int32, "@complex_key": String))
+      named_tuple.should be_a NamedTuple(
+        a: Int32,
+        "@complex_key": String,
+        %[key_with_"quotes"]: String,
+      )
     end
 
     it "does for Bytes" do

--- a/spec/serialization_spec.cr
+++ b/spec/serialization_spec.cr
@@ -63,6 +63,18 @@ describe "MessagePack serialization" do
       tuple.should be_a(Tuple(Int32, String))
     end
 
+    it "does for NamedTuple" do
+      data = Bytes[130, 161, 97, 1, 172, 64, 99, 111, 109, 112, 108, 101, 120, 95, 107, 101, 121, 165, 119, 111, 114, 107, 115]
+
+      named_tuple = NamedTuple(a: Int32, "@complex_key": String).from_msgpack(data)
+
+      named_tuple.should eq({
+        a:              1,
+        "@complex_key": "works",
+      })
+      named_tuple.should be_a(NamedTuple(a: Int32, "@complex_key": String))
+    end
+
     it "does for Bytes" do
       data = UInt8[196, 3, 1, 2, 3]
       binary = Bytes.from_msgpack(data)

--- a/src/message_pack/from_msgpack.cr
+++ b/src/message_pack/from_msgpack.cr
@@ -180,13 +180,13 @@ def NamedTuple.new(pull : MessagePack::Unpacker)
 
     {% for key, type in T %}
       if %var{key.id}.nil? && !::Union({{type}}).nilable?
-        raise MessagePack::TypeCastError.new("Missing msgpack attribute: {{key}}", token.byte_number)
+        raise MessagePack::TypeCastError.new("Missing msgpack attribute: #{ {{key.stringify}} }", token.byte_number)
       end
     {% end %}
 
     {
       {% for key, type in T %}
-        "{{key}}": %var{key.id}.as({{type}}),
+        {{key.stringify}}: %var{key.id}.as({{type}}),
       {% end %}
     }
   {% end %}

--- a/src/message_pack/from_msgpack.cr
+++ b/src/message_pack/from_msgpack.cr
@@ -186,7 +186,7 @@ def NamedTuple.new(pull : MessagePack::Unpacker)
 
     {
       {% for key, type in T %}
-        {{key}}: %var{key.id}.as({{type}}),
+        "{{key}}": %var{key.id}.as({{type}}),
       {% end %}
     }
   {% end %}


### PR DESCRIPTION
Simple NamedTuple keys (those using `\w` characters exclusively) are the most common, but Crystal supports others. The main thing we need to do is to wrap the key in quotes, but since they can also have quotes, we need to use the `stringify` macro method to ensure they're properly escaped.

There wasn't a `NamedTuple.from_msgpack` test, so I added one.